### PR TITLE
Load rental panel data from new meta keys with legacy fallbacks

### DIFF
--- a/admin/views/panel-rental-insurance.php
+++ b/admin/views/panel-rental-insurance.php
@@ -12,8 +12,65 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-// Get saved data
-$insurance_options = get_post_meta( $product_id, '_rental_insurance', true ) ?: array();
+// Helper to normalize stored meta values into arrays.
+if ( ! function_exists( 'wcrbtw_maybe_decode_meta_array' ) ) {
+    /**
+     * Attempt to decode a stored meta value into an array.
+     *
+     * @param mixed $value Stored meta value.
+     * @return array
+     */
+    function wcrbtw_maybe_decode_meta_array( $value ): array {
+        if ( empty( $value ) && '0' !== $value ) {
+            return array();
+        }
+
+        if ( is_array( $value ) ) {
+            return $value;
+        }
+
+        if ( is_string( $value ) ) {
+            $trimmed_value = trim( $value );
+
+            if ( '' === $trimmed_value ) {
+                return array();
+            }
+
+            $decoded = json_decode( $trimmed_value, true );
+            if ( is_array( $decoded ) ) {
+                return $decoded;
+            }
+
+            if ( function_exists( 'maybe_unserialize' ) ) {
+                $unserialized = maybe_unserialize( $value );
+                if ( is_array( $unserialized ) ) {
+                    return $unserialized;
+                }
+            }
+
+            $lines = array_filter(
+                array_map( 'trim', preg_split( '/[\r\n]+/', $value ) )
+            );
+
+            if ( ! empty( $lines ) ) {
+                return array_values( $lines );
+            }
+        }
+
+        return array();
+    }
+}
+
+// Get saved data from new meta keys, falling back to legacy `_rental_*` when needed.
+$insurance_meta_exists = metadata_exists( 'post', $product_id, '_wcrbtw_insurance' );
+$insurance_options     = $insurance_meta_exists
+    ? wcrbtw_maybe_decode_meta_array( get_post_meta( $product_id, '_wcrbtw_insurance', true ) )
+    : array();
+
+if ( ! $insurance_meta_exists ) {
+    $insurance_options = wcrbtw_maybe_decode_meta_array( get_post_meta( $product_id, '_rental_insurance', true ) );
+}
+
 $currency = get_woocommerce_currency_symbol();
 ?>
 

--- a/admin/views/panel-rental-settings.php
+++ b/admin/views/panel-rental-settings.php
@@ -12,8 +12,126 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-// Get saved data
-$settings = get_post_meta( $product_id, '_rental_settings', true ) ?: array();
+// Helper to normalize stored meta values into arrays.
+if ( ! function_exists( 'wcrbtw_maybe_decode_meta_array' ) ) {
+    /**
+     * Attempt to decode a stored meta value into an array.
+     *
+     * @param mixed $value Stored meta value.
+     * @return array
+     */
+    function wcrbtw_maybe_decode_meta_array( $value ): array {
+        if ( empty( $value ) && '0' !== $value ) {
+            return array();
+        }
+
+        if ( is_array( $value ) ) {
+            return $value;
+        }
+
+        if ( is_string( $value ) ) {
+            $trimmed_value = trim( $value );
+
+            if ( '' === $trimmed_value ) {
+                return array();
+            }
+
+            $decoded = json_decode( $trimmed_value, true );
+            if ( is_array( $decoded ) ) {
+                return $decoded;
+            }
+
+            if ( function_exists( 'maybe_unserialize' ) ) {
+                $unserialized = maybe_unserialize( $value );
+                if ( is_array( $unserialized ) ) {
+                    return $unserialized;
+                }
+            }
+
+            $lines = array_filter(
+                array_map( 'trim', preg_split( '/[\r\n]+/', $value ) )
+            );
+
+            if ( ! empty( $lines ) ) {
+                return array_values( $lines );
+            }
+        }
+
+        return array();
+    }
+}
+
+// Retrieve settings from new meta keys, with legacy fallbacks.
+$settings_meta_exists = array(
+    'min_days'            => metadata_exists( 'post', $product_id, '_wcrbtw_min_days' ),
+    'max_days'            => metadata_exists( 'post', $product_id, '_wcrbtw_max_days' ),
+    'extra_day_hour'      => metadata_exists( 'post', $product_id, '_wcrbtw_extra_day_hour' ),
+    'security_deposit'    => metadata_exists( 'post', $product_id, '_wcrbtw_security_deposit' ),
+    'cancellation_policy' => metadata_exists( 'post', $product_id, '_wcrbtw_cancellation_policy' ),
+    'additional_settings' => metadata_exists( 'post', $product_id, '_wcrbtw_additional_settings' ),
+);
+
+$settings = array(
+    'min_days'            => $settings_meta_exists['min_days'] ? get_post_meta( $product_id, '_wcrbtw_min_days', true ) : null,
+    'max_days'            => $settings_meta_exists['max_days'] ? get_post_meta( $product_id, '_wcrbtw_max_days', true ) : null,
+    'extra_day_hour'      => $settings_meta_exists['extra_day_hour'] ? get_post_meta( $product_id, '_wcrbtw_extra_day_hour', true ) : null,
+    'security_deposit'    => $settings_meta_exists['security_deposit'] ? get_post_meta( $product_id, '_wcrbtw_security_deposit', true ) : null,
+    'cancellation_policy' => $settings_meta_exists['cancellation_policy'] ? get_post_meta( $product_id, '_wcrbtw_cancellation_policy', true ) : null,
+    'additional_settings' => $settings_meta_exists['additional_settings'] ? get_post_meta( $product_id, '_wcrbtw_additional_settings', true ) : null,
+);
+
+$legacy_settings = wcrbtw_maybe_decode_meta_array( get_post_meta( $product_id, '_rental_settings', true ) );
+
+foreach ( $settings_meta_exists as $key => $meta_exists ) {
+    if ( ! $meta_exists && isset( $legacy_settings[ $key ] ) ) {
+        $legacy_value     = $legacy_settings[ $key ];
+        $settings[ $key ] = is_scalar( $legacy_value ) ? (string) $legacy_value : null;
+    }
+}
+
+// Additional fallbacks for individual legacy meta keys.
+if ( ! $settings_meta_exists['min_days'] && null === $settings['min_days'] ) {
+    $legacy_min_days = get_post_meta( $product_id, '_rental_min_days', true );
+    if ( '' !== $legacy_min_days ) {
+        $settings['min_days'] = $legacy_min_days;
+    }
+}
+
+if ( ! $settings_meta_exists['max_days'] && null === $settings['max_days'] ) {
+    $legacy_max_days = get_post_meta( $product_id, '_rental_max_days', true );
+    if ( '' !== $legacy_max_days ) {
+        $settings['max_days'] = $legacy_max_days;
+    }
+}
+
+if ( ! $settings_meta_exists['extra_day_hour'] && null === $settings['extra_day_hour'] ) {
+    $legacy_extra_day_hour = get_post_meta( $product_id, '_rental_extra_day_hour', true );
+    if ( '' !== $legacy_extra_day_hour ) {
+        $settings['extra_day_hour'] = $legacy_extra_day_hour;
+    }
+}
+
+if ( ! $settings_meta_exists['security_deposit'] && null === $settings['security_deposit'] ) {
+    $legacy_security_deposit = get_post_meta( $product_id, '_rental_security_deposit', true );
+    if ( '' !== $legacy_security_deposit ) {
+        $settings['security_deposit'] = $legacy_security_deposit;
+    }
+}
+
+if ( ! $settings_meta_exists['cancellation_policy'] && null === $settings['cancellation_policy'] ) {
+    $legacy_cancellation_policy = get_post_meta( $product_id, '_rental_cancellation_policy', true );
+    if ( '' !== $legacy_cancellation_policy ) {
+        $settings['cancellation_policy'] = $legacy_cancellation_policy;
+    }
+}
+
+if ( ! $settings_meta_exists['additional_settings'] && null === $settings['additional_settings'] ) {
+    $legacy_additional_settings = get_post_meta( $product_id, '_rental_additional_settings', true );
+    if ( '' !== $legacy_additional_settings ) {
+        $settings['additional_settings'] = $legacy_additional_settings;
+    }
+}
+
 $currency = get_woocommerce_currency_symbol();
 ?>
 
@@ -134,19 +252,24 @@ $currency = get_woocommerce_currency_symbol();
             <p class="description">
                 <strong><?php esc_html_e( 'Current Configuration:', 'woocommerce-car-rental' ); ?></strong>
             </p>
+            <?php
+            $summary_min_days       = isset( $settings['min_days'] ) && '' !== $settings['min_days'] ? absint( $settings['min_days'] ) : 1;
+            $summary_max_days       = isset( $settings['max_days'] ) && '' !== $settings['max_days'] ? absint( $settings['max_days'] ) : 30;
+            $summary_extra_day_hour = isset( $settings['extra_day_hour'] ) && '' !== $settings['extra_day_hour'] ? absint( $settings['extra_day_hour'] ) : 14;
+            ?>
             <ul style="margin-left: 20px; list-style: disc;">
-                <li><?php printf( 
-                    esc_html__( 'Rental period: %d to %d days', 'woocommerce-car-rental' ), 
-                    $settings['min_days'] ?? 1, 
-                    $settings['max_days'] ?? 30 
+                <li><?php printf(
+                    esc_html__( 'Rental period: %d to %d days', 'woocommerce-car-rental' ),
+                    $summary_min_days,
+                    $summary_max_days
                 ); ?></li>
-                <li><?php printf( 
-                    esc_html__( 'Extra day charged after: %d:00', 'woocommerce-car-rental' ), 
-                    $settings['extra_day_hour'] ?? 14 
+                <li><?php printf(
+                    esc_html__( 'Extra day charged after: %d:00', 'woocommerce-car-rental' ),
+                    $summary_extra_day_hour
                 ); ?></li>
                 <?php if ( ! empty( $settings['security_deposit'] ) ) : ?>
-                <li><?php printf( 
-                    esc_html__( 'Security deposit: %s%s', 'woocommerce-car-rental' ), 
+                <li><?php printf(
+                    esc_html__( 'Security deposit: %s%s', 'woocommerce-car-rental' ),
                     $currency,
                     wc_format_localized_price( $settings['security_deposit'] )
                 ); ?></li>


### PR DESCRIPTION
## Summary
- normalize rental availability data from the new `_wcrbtw_*` meta keys while falling back to legacy `_rental_*` values when needed
- populate services and insurance forms from the JSON stored `_wcrbtw_*` meta with graceful legacy fallbacks
- read the settings panel fields from the new meta keys and adjust the summary display to honour defaults when values are absent

## Testing
- php -l admin/views/panel-rental-availability.php
- php -l admin/views/panel-rental-services.php
- php -l admin/views/panel-rental-insurance.php
- php -l admin/views/panel-rental-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68cdff1b52d48333acbb72f0da7a1c9d